### PR TITLE
Make ELB working for Pods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 dev.values.yaml
+test.values.yaml
 prod.values.yaml
 planet.values.yaml
 postgres-data/

--- a/helm/osm-seed/templates/id-editor-service.yaml
+++ b/helm/osm-seed/templates/id-editor-service.yaml
@@ -9,9 +9,9 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   type: {{ .Values.idEditor.serviceType }}
-  {{- if .Values.idEditor.staticIp.enabled }}
-  loadBalancerIP : {{ .Values.idEditor.staticIp.ip }}
-  {{- end }}
+  # {{- if .Values.idEditor.staticIp.enabled }}
+  # loadBalancerIP : {{ .Values.idEditor.staticIp.ip }}
+  # {{- end }}
   ports:
     - port: 80
       targetPort: http

--- a/helm/osm-seed/templates/web-service.yaml
+++ b/helm/osm-seed/templates/web-service.yaml
@@ -9,9 +9,9 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   type: {{ .Values.web.serviceType }}
-  {{- if .Values.web.staticIp.enabled }}
-  loadBalancerIP : {{ .Values.web.staticIp.ip }}
-  {{- end }}
+  # {{- if .Values.web.staticIp.enabled }}
+  # loadBalancerIP : {{ .Values.web.staticIp.ip }}
+  # {{- end }}
   ports:
     - port: 80
       targetPort: http


### PR DESCRIPTION
Using this configuration works good in EKS, but still pending to test in GCP. 
in GCP, we have to create a fixed IP and set it in the values.yaml,  but in EKS  the service is running through ELB. 


cc. @batpad 