### PR TITLE
Update settings.yml, override iD and other envs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   web:
     image: osmseed-openstreetmap-website:v1
     build:
-      context: ./openstreetmap-website
+      context: ./images/web
       dockerfile: Dockerfile
     ports:
       - "80:80"
@@ -14,7 +14,7 @@ services:
   db:
     image: osmseed-db:v1
     build:
-      context: ./db
+      context: ./images/db
       dockerfile: Dockerfile
     ports:
       - "5432:5432"
@@ -25,7 +25,7 @@ services:
   planet-dump:
     image: osmseed-planet-dump:v1
     build:
-      context: ./planet-dump
+      context: ./images/planet-dump
       dockerfile: Dockerfile
     depends_on:
       - db
@@ -42,7 +42,7 @@ services:
   db-backup-restore:
     image: osmseed-db-backup-restore:v1
     build: 
-      context: ./db-backup-restore
+      context: ./images/backup-restore
       dockerfile: Dockerfile
     depends_on:
       - db
@@ -57,7 +57,7 @@ services:
   replication-job:
     image: osmseed-replication-job:v1
     build:
-      context: ./replication-job
+      context: ./images/replication-job
       dockerfile: Dockerfile
     volumes:
       - ./replication-job:/mnt/data
@@ -74,7 +74,7 @@ services:
   populate-apidb:
     image: osmseed-populate-apidb:v1
     build:
-      context: ./populate-apidb
+      context: ./images/populate-apidb
       dockerfile: Dockerfile
     volumes:
       - ./populate-apidb-data:/app/data
@@ -91,14 +91,14 @@ services:
   osm-processor:
     image: osmseed-osm-processor:v1
     build:
-      context: ./osm-processor
+      context: ./images/osm-processor
       dockerfile: Dockerfile
     env_file:
       - ./.env
   full-history:
     image: osmseed-full-history:v1
     build:
-      context: ./full-history
+      context: ./images/full-history
       dockerfile: Dockerfile
     depends_on:
       - web
@@ -119,7 +119,7 @@ services:
   tiler-db:
     image: osmseed-tiler-db:v1
     build: 
-      context: ./tiler-db
+      context: ./images/tiler-db
       dockerfile: Dockerfile
     ports:
       -  "5433:5432"
@@ -130,7 +130,7 @@ services:
   tiler-imposm:
     image: osmseed-tiler-imposm:v1
     build: 
-      context: ./tiler-imposm
+      context: ./images/tiler-imposm
       dockerfile: Dockerfile
     volumes:
       - ./tiler-imposm-data:/mnt/data
@@ -147,7 +147,7 @@ services:
   tiler-server:
     image: osmseed-tiler-server:v1
     build: 
-      context: ./tiler-server
+      context: ./images/tiler-server
       dockerfile: Dockerfile
     volumes:
       - ./tiler-server-data:/mnt/data

--- a/images/backup-restore/Dockerfile
+++ b/images/backup-restore/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:16.04
 ENV workdir /app
-RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
     wget \
     python-pip \
     software-properties-common \

--- a/images/db/Dockerfile
+++ b/images/db/Dockerfile
@@ -1,6 +1,5 @@
 FROM postgres:9.5
-RUN apt-get update
-RUN apt-get install -y make \
+RUN apt-get update && apt-get install -y make \
     postgresql-server-dev-9.5 \
     build-essential \
     postgresql-9.5-postgis-2.3 \

--- a/images/osm-processor/Dockerfile
+++ b/images/osm-processor/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:16.04
 ENV workdir /mnt/data
-RUN apt-get -y update
-RUN apt-get -y install \
+RUN apt-get -y update && apt-get -y install \
     build-essential \
     libboost-program-options-dev \
     libbz2-dev \

--- a/images/replication-job/Dockerfile
+++ b/images/replication-job/Dockerfile
@@ -3,4 +3,4 @@ FROM developmentseed/osmseed-osm-processor:ohm-7dd7b8a
 WORKDIR /mnt/data
 # VOLUME ["/mnt/data"]
 COPY ./start.sh .
-CMD ./start.sh
+# CMD ./start.sh

--- a/images/tiler-db/Dockerfile
+++ b/images/tiler-db/Dockerfile
@@ -1,6 +1,5 @@
 FROM mdillon/postgis:9.5
-RUN apt-get update
-RUN apt-get install -y git ca-certificates
+RUN apt-get update && apt-get install -y git ca-certificates
 
 COPY ./config/docker-entrypoint.sh /usr/local/bin/
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/images/tiler-imposm/Dockerfile
+++ b/images/tiler-imposm/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt-get -y update
-RUN apt-get install -y \
+RUN apt-get -y update && apt-get install -y \
      \
     g++ \
     git-core \

--- a/images/tiler-server/Dockerfile
+++ b/images/tiler-server/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang:1.14.1-alpine3.11 AS build
 ENV VERSION="v0.8.1"
-RUN apk update
-RUN apk add musl-dev=1.1.24-r2 \
+RUN apk update && apk add musl-dev=1.1.24-r3 \
 	gcc \
     bash \
     git \

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -113,7 +113,7 @@ RUN /usr/sbin/passenger-memory-stats
 RUN rm -rf $workdir
 RUN git clone https://github.com/openstreetmap/openstreetmap-website.git $workdir 
 WORKDIR $workdir
-# RUN git checkout master
+RUN git checkout master
 
 # Install the javascript runtime required by the `execjs` gem in
 RUN apt-get install -y libv8-dev
@@ -122,7 +122,7 @@ RUN echo "gem 'mini_racer'" >> Gemfile
 RUN gem install nokogiri -- --use-system-libraries
 
 # Install app dependencies
-RUN bundle install
+RUN bundle install 
 RUN gem install rake
 
 # update vendored iD
@@ -131,10 +131,10 @@ RUN vendorer
 
 # Configure database.yml, application.yml and secrets.yml
 ADD config/database.yml $workdir/config/database.yml
-RUN touch $workdir/config/settings.local.yml
+# RUN touch $workdir/config/settings.local.yml
 RUN cp $workdir/config/example.storage.yml $workdir/config/storage.yml
 
-# ADD config/application.yml $workdir/config/application.yml
+ADD config/application.yml $workdir/config/settings.local.yml
 RUN echo "#session key \n\
 production: \n\
   secret_key_base: $(bundle exec rake secret)" > $workdir/config/secrets.yml

--- a/images/web/config/application.yml
+++ b/images/web/config/application.yml
@@ -1,143 +1,139 @@
-defaults: &defaults
-  # The server URL
-  server_url: "localhost"
-  server_protocol: "http"
-  # The generator
-  generator: "OpenStreetMap server"
-  copyright_owner: "OpenStreetMap and contributors"
-  attribution_url: "http://www.openstreetmap.org/copyright"
-  license_url: "http://opendatacommons.org/licenses/odbl/1-0/"
-  # Support email address
-  support_email: "MAILER_SENDER_EMAIL"
-  # Sender addresses for emails
-  email_from: "openstreeetmap <osmseed-test@developmentseed.org>"
-  email_return_path: "osmseed-test@developmentseed.org"
-  # API version
-  api_version: "0.6"
-  # Application status - possible values are:
-  #   :online - online and operating normally
-  #   :api_readonly - site online but API in read-only mode
-  #   :api_offline - site online but API offline
-  #   :database_readonly - database and site in read-only mode
-  #   :database_offline - database offline with site in emergency mode
-  #   :gpx_offline - gpx storage offline
-  status: :online
-  # The maximum area you're allowed to request, in square degrees
-  max_request_area: 0.25
-  # Number of GPS trace/trackpoints returned per-page
-  tracepoints_per_page: 5000
-  # Maximum number of nodes that will be returned by the api in a map request
-  max_number_of_nodes: 50000
-  # Maximum number of nodes that can be in a way (checked on save)
-  max_number_of_way_nodes: 2000
-  # The maximum area you're allowed to request notes from, in square degrees
-  max_note_request_area: 25
-  # Zoom level to use for postcode results from the geocoder
-  postcode_zoom: 15
-  # Zoom level to use for geonames results from the geocoder
-  geonames_zoom: 12
-  # Timeout for API calls in seconds
-  api_timeout: 300
-  # Timeout for web pages in seconds
-  web_timeout: 30
-  # Periods (in hours) which are allowed for user blocks
-  user_block_periods: [0, 1, 3, 6, 12, 24, 48, 96]
-  # Rate limit for message sending
-  max_messages_per_hour: 60
-  # Domain for handling message replies
-  #messages_domain: "messages.openstreetmap.org"
-  # Geonames authentication details
-  #geonames_username: ""
-  # Quova authentication details
-  #quova_username: ""
-  #quova_password: ""
-  # Users to show as being nearby
-  nearby_users: 30
-  # Max radius, in km, for nearby users
-  nearby_radius: 50
-  # Spam threshold
-  spam_threshold: 50
-  # Default legale (jurisdiction location) for contributor terms
-  default_legale: GB
-  # Location of GPX traces and images
-  gpx_trace_dir: "/home/osm/traces"
-  gpx_image_dir: "/home/osm/images"
-  # Location of data for attachments
-  attachments_dir: ":rails_root/public/attachments"
-  # Log file to use
-  #log_path: ""
-  # Log file to use for logstash
-  #logstash_path: ""
-  # List of memcache servers to use for caching
-  #memcache_servers: []
-  # Enable legacy OAuth 1.0 support
-  oauth_10_support: true
-  # URL of Nominatim instance to use for geocoding
-  nominatim_url: "http//nominatim.openstreeetmap.org/"
-  # Default editor
-  default_editor: "id"
-  # OAuth consumer key for Potlatch 2
-  #potlatch2_key: ""
-  # OAuth consumer key for the web site
-  #oauth_key: ""
-  # OAuth consumer key for iD
-  id_key: "id-key-to-be-replaced"
-  # Whether to require users to view the CTs before continuing to edit...
-  require_terms_seen: false
-  # Whether to require users to agree to the CTs before editing
-  require_terms_agreed: false
-  # Imagery to return in capabilities as blacklisted
-  imagery_blacklist:
-    # Current Google imagery URLs have google or googleapis in the domain
-    # with a vt or kh endpoint, and x, y and z query parameters
-    - ".*\\.google(apis)?\\..*/(vt|kh)[\\?/].*([xyz]=.*){3}.*"
-  # URL of Overpass instance to use for feature queries
-  overpass_url: "https://overpass-api.de/api/interpreter"
-  # Routing endpoints
-  graphhopper_url: "https://graphhopper.com/api/1/route"
-  mapquest_directions_url: "https://open.mapquestapi.com/directions/v2/route"
-  osrm_url: "https://router.project-osrm.org/route/v1/driving/"
-  
-  # External authentication credentials
-  #google_auth_id: ""
-  #google_auth_secret: ""
-  #google_openid_realm: ""
-  #facebook_auth_id: ""
-  #facebook_auth_secret: ""
-  #windowslive_auth_id: ""
-  #windowslive_auth_secret: ""
-  #github_auth_id: ""
-  #github_auth_secret: ""
-  # MapQuest authentication details
-  #mapquest_key: ""
-  # Mapzen authentication details
-  #mapzen_valhalla_key: ""
-  # Thunderforest authentication details
-  #thunderforest_key: ""
- # Key for generating TOTP tokens
-  #totp_key: ""
-  # Enforce Content-Security-Policy
-  csp_enforce: false
-  # URL for reporting Content-Security-Policy violations
-  #csp_report_url: ""
-
-development:
-  <<: *defaults
-
-production:
-  <<: *defaults
-
-test:
-  <<: *defaults
-  # Geonames credentials for testing
-  geonames_username: "dummy"
-  # External authentication credentials for testing
-  google_auth_id: "dummy"
-  google_auth_secret: "dummy"
-  google_openid_realm: "https://www.openstreetmap.org"
-  facebook_auth_id: "dummy"
-  facebook_auth_secret: "dummy"
-  windowslive_auth_id: "dummy"
-  windowslive_auth_secret: "dummy"
-  github_auth_id: "dummy"
-  github_auth_secret: "dummy" 
+# The server protocol and host
+server_protocol: "http"
+server_url: "openstreetmap.example.com"
+# Publisher
+#publisher_url: ""
+# The generator
+generator: "OpenStreetMap server"
+copyright_owner: "OpenStreetMap and contributors"
+attribution_url: "http://www.openstreetmap.org/copyright"
+license_url: "http://opendatacommons.org/licenses/odbl/1-0/"
+# Support email address
+support_email: "openstreetmap@example.com"
+# Sender addresses for emails
+email_from: "OpenStreetMap <openstreetmap@example.com>"
+email_return_path: "openstreetmap@example.com"
+# API version
+api_version: "0.6"
+# Application status - possible values are:
+#   online - online and operating normally
+#   api_readonly - site online but API in read-only mode
+#   api_offline - site online but API offline
+#   database_readonly - database and site in read-only mode
+#   database_offline - database offline with site in emergency mode
+#   gpx_offline - gpx storage offline
+status: "online"
+# The maximum area you're allowed to request, in square degrees
+max_request_area: 0.25
+# Number of GPS trace/trackpoints returned per-page
+tracepoints_per_page: 5000
+# Maximum number of nodes that will be returned by the api in a map request
+max_number_of_nodes: 50000
+# Maximum number of nodes that can be in a way (checked on save)
+max_number_of_way_nodes: 2000
+# The maximum area you're allowed to request notes from, in square degrees
+max_note_request_area: 25
+# Zoom level to use for postcode results from the geocoder
+postcode_zoom: 15
+# Zoom level to use for geonames results from the geocoder
+geonames_zoom: 12
+# Timeout for API calls in seconds
+api_timeout: 300
+# Timeout for web pages in seconds
+web_timeout: 30
+# Periods (in hours) which are allowed for user blocks
+user_block_periods: [0, 1, 3, 6, 12, 24, 48, 96, 168, 336, 731, 4383, 8766, 87660]
+# Rate limit for message sending
+max_messages_per_hour: 60
+# Domain for handling message replies
+#messages_domain: "messages.openstreetmap.org"
+# Geonames authentication details
+#geonames_username: ""
+# MaxMind GeoIPv2 database
+#maxmind_database: ""
+# Users to show as being nearby
+nearby_users: 30
+# Max radius, in km, for nearby users
+nearby_radius: 50
+# Spam threshold
+spam_threshold: 50
+# Delay diary entries from appearing in the feed for this many hours
+diary_feed_delay: 0
+# Default legale (jurisdiction location) for contributor terms
+default_legale: GB
+# Use the built-in jobs queue for importing traces
+# Set to false if you are using the external high-speed gpx importer
+# https://github.com/openstreetmap/gpx-import
+trace_use_job_queue: true
+# Location of GPX traces and images
+gpx_trace_dir: "/home/osm/traces"
+gpx_image_dir: "/home/osm/images"
+# Location of data for attachments
+attachments_dir: ":rails_root/public/attachments"
+# Log file to use
+#log_path: ""
+# Log file to use for logstash
+#logstash_path: ""
+# List of memcache servers to use for caching
+#memcache_servers: []
+# Enable legacy OAuth 1.0 support
+oauth_10_support: true
+# URL of Nominatim instance to use for geocoding
+nominatim_url: "https://nominatim.openstreetmap.org/"
+# Default editor
+default_editor: "id"
+# OAuth consumer key for the web site
+#oauth_key: ""
+# OAuth consumer key for iD
+id_key: "id-key"
+# Imagery to return in capabilities as blacklisted
+imagery_blacklist:
+  # Current Google imagery URLs have google or googleapis in the domain
+  # with a vt or kh endpoint, and x, y and z query parameters
+  - ".*\\.google(apis)?\\..*/(vt|kh)[\\?/].*([xyz]=.*){3}.*"
+  # Blacklist VWorld
+  - "http://xdworld\\.vworld\\.kr:8080/.*"
+  # Blacklist here
+  - ".*\\.here\\.com[/:].*"
+  # Blacklist Kanton SH and GL
+  - ".*wms.geo.sh.ch.*Luftbild_201[06].*"
+  - ".*wms.geo.gl.ch.*ch.gl.imagery.orthofoto201[357].*"
+# URL of Overpass instance to use for feature queries
+overpass_url: "https://overpass-api.de/api/interpreter"
+# Routing endpoints
+graphhopper_url: "https://graphhopper.com/api/1/route"
+fossgis_osrm_url: "https://routing.openstreetmap.de/"
+# External authentication credentials
+#google_auth_id: ""
+#google_auth_secret: ""
+#google_openid_realm: ""
+#facebook_auth_id: ""
+#facebook_auth_secret: ""
+#windowslive_auth_id: ""
+#windowslive_auth_secret: ""
+#github_auth_id: ""
+#github_auth_secret: ""
+#wikipedia_auth_id: ""
+#wikipedia_auth_secret: ""
+# Thunderforest authentication details
+#thunderforest_key: ""
+# Key for generating TOTP tokens
+#totp_key: ""
+# Enforce Content-Security-Policy
+csp_enforce: false
+# URL for reporting Content-Security-Policy violations
+#csp_report_url: ""
+# Storage service to use in production mode
+storage_service: "local"
+# Root URL for storage service
+# storage_url:
+# URL for tile CDN
+#tile_cdn_url: ""
+# SMTP settings for outbound mail
+smtp_address: "localhost"
+smtp_port: 25
+smtp_domain: "localhost"
+smtp_enable_starttls_auto: false
+smtp_authentication: null
+smtp_user_name: null
+smtp_password: null

--- a/images/web/start.sh
+++ b/images/web/start.sh
@@ -12,14 +12,16 @@ production:
   encoding: utf8" > $workdir/config/database.yml
 
 # Setting up the SERVER_URL and SERVER_PROTOCOL
-sed -i -e 's/server_url: "localhost"/server_url: "'$SERVER_URL'"/g' $workdir/config/settings.local.yml
-sed -i -e 's/server_protocol: "http"/server_protocol: "'$SERVER_PROTOCOL'"/g' $workdir/config/settings.local.yml
+# Rails is supposed to pick up env with OPENSTREETMAP prefix but for some reason this is not the case
+# So we'll just manually override the settings.local.yml for now
+sed -i -e 's/server_url: "localhost"/server_url: "'$OPENSTREETMAP_server_url'"/g' $workdir/config/settings.local.yml
+sed -i -e 's/server_protocol: "http"/server_protocol: "'$OPENSTREETMAP_server_protocol'"/g' $workdir/config/settings.local.yml
 
 # # Setting up the email
-sed -i -e 's/osmseed-test@developmentseed.org/'$MAILER_FROM'/g' $workdir/config/settings.local.yml
+sed -i -e 's/openstreetmap@example.com/'$MAILER_SENDER_EMAIL'/g' $workdir/config/settings.local.yml
 
 # # Set up iD key
-sed -i -e 's/id-key-to-be-replaced/'$OSM_id_key'/g' $workdir/config/settings.local.yml
+sed -i -e 's/id-key/'$OPENSTREETMAP_id_key'/g' $workdir/config/settings.local.yml
 
 
 

--- a/images/web/start.sh
+++ b/images/web/start.sh
@@ -32,7 +32,7 @@ while "$flag" = true; do
   pg_isready -h $POSTGRES_HOST -p 5432 >/dev/null 2>&2 || continue
   flag=false
   # Print the log while compiling the assets
-  until $(curl -sf -o /dev/null $SERVER_URL); do
+  until $(curl -sf -o /dev/null $OPENSTREETMAP_server_url); do
       echo "Waiting to start rails ports server..."
       sleep 2
   done &

--- a/images/web/start.sh
+++ b/images/web/start.sh
@@ -12,14 +12,14 @@ production:
   encoding: utf8" > $workdir/config/database.yml
 
 # Setting up the SERVER_URL and SERVER_PROTOCOL
-# sed -i -e 's/server_url: "localhost"/server_url: "'$SERVER_URL'"/g' $workdir/config/application.yml
-# sed -i -e 's/server_protocol: "http"/server_protocol: "'$SERVER_PROTOCOL'"/g' $workdir/config/application.yml
+sed -i -e 's/server_url: "localhost"/server_url: "'$SERVER_URL'"/g' $workdir/config/settings.local.yml
+sed -i -e 's/server_protocol: "http"/server_protocol: "'$SERVER_PROTOCOL'"/g' $workdir/config/settings.local.yml
 
 # # Setting up the email
-# sed -i -e 's/osmseed-test@developmentseed.org/'$MAILER_FROM'/g' $workdir/config/application.yml
+sed -i -e 's/osmseed-test@developmentseed.org/'$MAILER_FROM'/g' $workdir/config/settings.local.yml
 
 # # Set up iD key
-# sed -i -e 's/id-key-to-be-replaced/'$OSM_id_key'/g' $workdir/config/application.yml
+sed -i -e 's/id-key-to-be-replaced/'$OSM_id_key'/g' $workdir/config/settings.local.yml
 
 
 


### PR DESCRIPTION
This PR supersedes #185. Thank you @dakotabenjamin for all the work you did to make sure docker-compose can build. After a little bit of testing I noticed that the envvars weren't actually getting picked up by rails. This is why iD wasn't working.

Here's what I did to debug this:
1. Noticed the alert message "iD is not configued'
2. Tracked down where that is coming from https://github.com/openstreetmap/openstreetmap-website/blob/d41737c6a0e4a639545268e09e438575f92e7709/app/assets/javascripts/edit/id.js.erb#L46
3. This is because the key is not set
4. SSH into the web container and looked at the settings.local.yml, it doesn't have the key
5. Though the rails env do have the `OPENSTREETMAP_id_key` this isn't getting picked up
6. Tried a few things like compile assets during runtime, none of it helped
7. In the end fallback to updating settings.local.yml with id key using sed

@Rub21 @batpad 