### PR TITLE
Ensure unique name for letsencrypt issues

### DIFF
--- a/osm-seed/templates/letsencrypt-issuer.yaml
+++ b/osm-seed/templates/letsencrypt-issuer.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-    name: {{ template "osm-seed.fullname" . }}-letsencrypt-prod-issuer
+    name: {{ template ".Release.Name" . }}-letsencrypt-prod-issuer
 spec:
     acme:
         # You must replace this email address with your own.

--- a/osm-seed/templates/letsencrypt-issuer.yaml
+++ b/osm-seed/templates/letsencrypt-issuer.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-    name: letsencrypt-prod-issuer
+    name: {{ template "osm-seed.fullname" . }}-letsencrypt-prod-issuer
 spec:
     acme:
         # You must replace this email address with your own.


### PR DESCRIPTION
To be honest I don't know if this is the correct solution, but I ran into an issue trying to setup a second stack where it failed trying to create a ClusterIssuer resource that already existed.
