### PR TITLE
Overpass  - Passing replication sequence number

### DIFF
--- a/images/overpass-api/docker-entrypoint.sh
+++ b/images/overpass-api/docker-entrypoint.sh
@@ -11,6 +11,8 @@ OVERPASS_CLONE_SOURCE=${OVERPASS_CLONE_SOURCE:-http://dev.overpass-api.de/api_dr
 # this is used by other processes, so needs to be exported
 export OVERPASS_MAX_TIMEOUT=${OVERPASS_MAX_TIMEOUT:-1000s}
 
+mkdir /db/replicate_id
+
 if [[ "$OVERPASS_META" == "attic" ]] ; then
     META="--keep-attic"
 elif [[ "${OVERPASS_META}" == "yes" ]] ; then

--- a/images/overpass-api/docker-entrypoint.sh
+++ b/images/overpass-api/docker-entrypoint.sh
@@ -11,8 +11,6 @@ OVERPASS_CLONE_SOURCE=${OVERPASS_CLONE_SOURCE:-http://dev.overpass-api.de/api_dr
 # this is used by other processes, so needs to be exported
 export OVERPASS_MAX_TIMEOUT=${OVERPASS_MAX_TIMEOUT:-1000s}
 
-mkdir /db/replicate_id
-
 if [[ "$OVERPASS_META" == "attic" ]] ; then
     META="--keep-attic"
 elif [[ "${OVERPASS_META}" == "yes" ]] ; then
@@ -92,6 +90,8 @@ if [[ ! -f /db/init_done ]] ; then
                 && touch /db/init_done \
                 && rm /db/planet.osm.bz2 \
                 && chown -R overpass:overpass /db \
+                && echo $OVERPASS_REPLICATION_SEQUENCE_NUMBER > /db/replicate_id \
+                && chmod 777 /db/replicate_id \
                 && echo "Overpass ready, you can start your container with docker start" \
                 && startAPIServer
               ) || (

--- a/osm-seed/templates/overpass-api/overpass-api-statefulset.yaml
+++ b/osm-seed/templates/overpass-api/overpass-api-statefulset.yaml
@@ -59,6 +59,8 @@ spec:
               value: {{ .Values.overpassApi.env.OVERPASS_RULES_LOAD | quote}}
             - name: OVERPASS_PLANET_PREPROCESS
               value: {{ .Values.overpassApi.env.OVERPASS_PLANET_PREPROCESS | quote}}
+            - OVERPASS_REPLICATION_SEQUENCE_NUMBER
+              value: {{ .Values.overpassApi.env.OVERPASS_REPLICATION_SEQUENCE_NUMBER }}
           volumeMounts:
           - mountPath: /db
             name: overpass-api-storage

--- a/osm-seed/templates/overpass-api/overpass-api-statefulset.yaml
+++ b/osm-seed/templates/overpass-api/overpass-api-statefulset.yaml
@@ -59,7 +59,7 @@ spec:
               value: {{ .Values.overpassApi.env.OVERPASS_RULES_LOAD | quote}}
             - name: OVERPASS_PLANET_PREPROCESS
               value: {{ .Values.overpassApi.env.OVERPASS_PLANET_PREPROCESS | quote}}
-            - OVERPASS_REPLICATION_SEQUENCE_NUMBER
+            - name: OVERPASS_REPLICATION_SEQUENCE_NUMBER
               value: {{ .Values.overpassApi.env.OVERPASS_REPLICATION_SEQUENCE_NUMBER | quote }}
           volumeMounts:
           - mountPath: /db

--- a/osm-seed/templates/overpass-api/overpass-api-statefulset.yaml
+++ b/osm-seed/templates/overpass-api/overpass-api-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
             - name: OVERPASS_PLANET_PREPROCESS
               value: {{ .Values.overpassApi.env.OVERPASS_PLANET_PREPROCESS | quote}}
             - OVERPASS_REPLICATION_SEQUENCE_NUMBER
-              value: {{ .Values.overpassApi.env.OVERPASS_REPLICATION_SEQUENCE_NUMBER }}
+              value: {{ .Values.overpassApi.env.OVERPASS_REPLICATION_SEQUENCE_NUMBER | quote }}
           volumeMounts:
           - mountPath: /db
             name: overpass-api-storage

--- a/osm-seed/values.yaml
+++ b/osm-seed/values.yaml
@@ -587,6 +587,7 @@ overpassApi:
     OVERPASS_RULES_LOAD: 10
     #OVERPASS_PLANET_PREPROCESS: 'mv /db/planet.osm.bz2 /db/planet.osm.pbf && osmium cat -o /db/planet.osm.bz2 /db/planet.osm.pbf && rm /db/planet.osm.pbf' # it is in case we pass planet files as PBF file uncommment this line
     OVERPASS_PLANET_PREPROCESS: 'ls'
+    OVERPASS_REPLICATION_SEQUENCE_NUMBER: 5201000
   persistenceDisk:
     enabled: false
     accessMode: ReadWriteOnce


### PR DESCRIPTION
This PR tends  to add a `OVERPASS_REPLICATION_SEQUENCE_NUMBER` in the env variable for Overpass in order to solve  the issue of not updating the Overpass-DB.

The container at the beginning is going to write the  `OVERPASS_REPLICATION_SEQUENCE_NUMBER` value ,  in a file called`/db/replicate_id`, the file  is going to be use as stating  the updates. 

cc. @batpad 