### PR TITLE
Fix data path in planet-dump compose

### DIFF
--- a/compose/planet-dump.yml
+++ b/compose/planet-dump.yml
@@ -17,7 +17,7 @@ services:
       context: ./images/planet-dump
       dockerfile: Dockerfile
     volumes:
-      - ./data/planet-dump-data:/mnt/data
+      - ../data/planet-dump-data:/mnt/data
     command: >
       /bin/bash -c "
         echo 'Set cronjob for planet-dump, every 4 minutes';


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Fix the data volume path in planet-dump compose config file to make data exported in /data instead of /compose/data

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Adding `..` instead of `.`

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Running `docker compose -f compose/planet-dump.yml run planet-dump`
