### PR TITLE
Add security context with fallback

### DIFF
--- a/osm-seed/templates/db/db-backup-job.yaml
+++ b/osm-seed/templates/db/db-backup-job.yaml
@@ -18,6 +18,10 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            runAsUser: {{ .Values.dbBackupRestore.runAsUser | default .Values.runAsUser | default 0 }}
+            runAsGroup: {{ .Values.dbBackupRestore.runAsGroup | default .Values.runAsGroup | default 0 }}
+            fsGroup: {{ .Values.dbBackupRestore.fsGroup | default .Values.fsGroup | default 0 }}
           containers:
           - name: {{ .Release.Name }}-db-backup-job
             image: {{ .Values.dbBackupRestore.image.name }}:{{ .Values.dbBackupRestore.image.tag }}

--- a/osm-seed/templates/db/db-statefulset.yaml
+++ b/osm-seed/templates/db/db-statefulset.yaml
@@ -23,6 +23,10 @@ spec:
         release: {{ .Release.Name }}
         run: {{ .Release.Name }}-db
     spec:
+      securityContext:
+        runAsUser: {{ .Values.db.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.db.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.db.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
         - name: {{ .Chart.Name }}-db
           image: "{{ .Values.db.image.name }}:{{ .Values.db.image.tag }}"

--- a/osm-seed/templates/id-editor/id-editor-deployment.yaml
+++ b/osm-seed/templates/id-editor/id-editor-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         release: {{ .Release.Name }}
         run: {{ .Release.Name }}-id-editor
     spec:
+      securityContext:
+        runAsUser: {{ .Values.idEditor.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.idEditor.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.idEditor.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
         - name: {{ .Chart.Name }}-id-editor
           image: "{{ .Values.idEditor.image }}:{{ .Values.osmSeedVersion }}"

--- a/osm-seed/templates/jobs/full-history-job.yaml
+++ b/osm-seed/templates/jobs/full-history-job.yaml
@@ -18,6 +18,10 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            runAsUser: {{ .Values.fullHistory.runAsUser | default .Values.runAsUser | default 0 }}
+            runAsGroup: {{ .Values.fullHistory.runAsGroup | default .Values.runAsGroup | default 0 }}
+            fsGroup: {{ .Values.fullHistory.fsGroup | default .Values.fsGroup | default 0 }}
           containers:
           - name: {{ .Release.Name }}-full-history-job
             image: {{ .Values.fullHistory.image.name }}:{{ .Values.fullHistory.image.tag }}

--- a/osm-seed/templates/jobs/osm-processor-job.yaml
+++ b/osm-seed/templates/jobs/osm-processor-job.yaml
@@ -11,6 +11,10 @@ metadata:
 spec:
     template:
       spec:
+        securityContext:
+          runAsUser: {{ .Values.osmProcessor.runAsUser | default .Values.runAsUser | default 0 }}
+          runAsGroup: {{ .Values.osmProcessor.runAsGroup | default .Values.runAsGroup | default 0 }}
+          fsGroup: {{ .Values.osmProcessor.fsGroup | default .Values.fsGroup | default 0 }}
         containers:
         - name: {{ .Release.Name }}-osm-processor-job
           image: {{ .Values.osmProcessor.image.name }}:{{ .Values.osmProcessor.image.tag }}

--- a/osm-seed/templates/jobs/planet-dump-job.yaml
+++ b/osm-seed/templates/jobs/planet-dump-job.yaml
@@ -18,6 +18,10 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            runAsUser: {{ .Values.planetDump.runAsUser | default .Values.runAsUser | default 0 }}
+            runAsGroup: {{ .Values.planetDump.runAsGroup | default .Values.runAsGroup | default 0 }}
+            fsGroup: {{ .Values.planetDump.fsGroup | default .Values.fsGroup | default 0 }}
           containers:
           - name: {{ .Release.Name }}-planet-dump-job
             image: {{ .Values.planetDump.image.name }}:{{ .Values.planetDump.image.tag }}

--- a/osm-seed/templates/jobs/populate-apidb-job.yaml
+++ b/osm-seed/templates/jobs/populate-apidb-job.yaml
@@ -11,6 +11,10 @@ metadata:
 spec:
     template:
       spec:
+        securityContext:
+          runAsUser: {{ .Values.populateApidb.runAsUser | default .Values.runAsUser | default 0 }}
+          runAsGroup: {{ .Values.populateApidb.runAsGroup | default .Values.runAsGroup | default 0 }}
+          fsGroup: {{ .Values.populateApidb.fsGroup | default .Values.fsGroup | default 0 }}
         containers:
         - name: {{ .Release.Name }}-populate-apidb-job
           image: {{ .Values.populateApidb.image.name }}:{{ .Values.populateApidb.image.tag }}

--- a/osm-seed/templates/jobs/replication-job-deployment.yaml
+++ b/osm-seed/templates/jobs/replication-job-deployment.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         app: {{ template "osm-seed.name" . }}
     spec:
+      securityContext:
+        runAsUser: {{ .Values.replicationJob.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.replicationJob.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.replicationJob.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
         - name: {{ .Release.Name }}-replication-job-deployment
           image: {{ .Values.replicationJob.image.name }}:{{ .Values.replicationJob.image.tag }}

--- a/osm-seed/templates/memcached/memcached-deployment.yml
+++ b/osm-seed/templates/memcached/memcached-deployment.yml
@@ -22,6 +22,10 @@ spec:
         release: {{ .Release.Name }}
         run: {{ .Release.Name }}-memcached
     spec:
+      securityContext:
+        runAsUser: {{ .Values.memcached.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.memcached.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.memcached.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
         - name: {{ .Chart.Name }}-memcached
           image: "memcached"

--- a/osm-seed/templates/nominatim-api/nominatim-api-statefulset.yaml
+++ b/osm-seed/templates/nominatim-api/nominatim-api-statefulset.yaml
@@ -23,6 +23,10 @@ spec:
         release: {{ .Release.Name }}
         run: {{ .Release.Name }}-nominatim-api
     spec:
+      securityContext:
+        runAsUser: {{ .Values.nominatimApi.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.nominatimApi.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.nominatimApi.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
         - name: {{ .Chart.Name }}-nominatim-api
           image: "{{ .Values.nominatimApi.image.name }}:{{ .Values.nominatimApi.image.tag }}"

--- a/osm-seed/templates/overpass-api/overpass-api-statefulset.yaml
+++ b/osm-seed/templates/overpass-api/overpass-api-statefulset.yaml
@@ -23,6 +23,10 @@ spec:
         release: {{ .Release.Name }}
         run: {{ .Release.Name }}-overpass-api
     spec:
+      securityContext:
+        runAsUser: {{ .Values.overpassApi.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.overpassApi.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.overpassApi.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
         - name: {{ .Chart.Name }}-overpass-api
           image: "{{ .Values.overpassApi.image.name }}:{{ .Values.overpassApi.image.tag }}"

--- a/osm-seed/templates/taginfo/taginfo-deployment.yaml
+++ b/osm-seed/templates/taginfo/taginfo-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         release: {{ .Release.Name }}
         run: {{ .Release.Name }}-taginfo
     spec:
+      securityContext:
+        runAsUser: {{ .Values.taginfo.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.taginfo.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.taginfo.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
         - name: {{ .Chart.Name }}-taginfo
           image: "{{ .Values.taginfo.image.name }}:{{ .Values.taginfo.image.tag }}"

--- a/osm-seed/templates/tasking-manager-api/tasking-manager-api-deployment.yaml
+++ b/osm-seed/templates/tasking-manager-api/tasking-manager-api-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         release: {{ .Release.Name }}
         run: {{ .Release.Name }}-tasking-manager-api
     spec:
+      securityContext:
+        runAsUser: {{ .Values.tmApi.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.tmApi.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.tmApi.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
         - name: {{ .Chart.Name }}-tasking-manager-api
           image: "{{ .Values.tmApi.image.name }}:{{ .Values.tmApi.image.tag }}"

--- a/osm-seed/templates/tiler-db/tiler-db-statefulset.yaml
+++ b/osm-seed/templates/tiler-db/tiler-db-statefulset.yaml
@@ -23,6 +23,10 @@ spec:
         release: {{ .Release.Name }}
         run: {{ .Release.Name }}-tiler-db
     spec:
+      securityContext:
+        runAsUser: {{ .Values.tilerDb.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.tilerDb.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.tilerDb.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
         - name: {{ .Chart.Name }}-tiler-db
           image: "{{ .Values.tilerDb.image.name }}:{{ .Values.tilerDb.image.tag }}"

--- a/osm-seed/templates/tiler-imposm/tiler-imposm-statefulset.yaml
+++ b/osm-seed/templates/tiler-imposm/tiler-imposm-statefulset.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         app: {{ .Release.Name }}-tiler-imposm-statefulset
     spec:
+      securityContext:
+        runAsUser: {{ .Values.tilerImposm.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.tilerImposm.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.tilerImposm.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
       - name: {{ .Release.Name }}-tiler-imposm-statefulset
         image: {{ .Values.tilerImposm.image.name }}:{{ .Values.tilerImposm.image.tag }}

--- a/osm-seed/templates/tiler-server/tiler-server-cache-cleaner-deployment.yaml
+++ b/osm-seed/templates/tiler-server/tiler-server-cache-cleaner-deployment.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         app: {{ template "osm-seed.name" . }}
     spec:
+      securityContext:
+        runAsUser: {{ .Values.tilerServerCacheCleaner.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.tilerServerCacheCleaner.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.tilerServerCacheCleaner.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
         - name: {{ .Release.Name }}-tiler-server-cache-cleaner-deployment
           image: {{ .Values.tilerServer.image.name }}:{{ .Values.tilerServer.image.tag }}

--- a/osm-seed/templates/tiler-server/tiler-server-deployment.yaml
+++ b/osm-seed/templates/tiler-server/tiler-server-deployment.yaml
@@ -23,6 +23,10 @@ spec:
         release: {{ .Release.Name }}
         run: {{ .Release.Name }}-tiler-server
     spec:
+      securityContext:
+        runAsUser: {{ .Values.tilerServer.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.tilerServer.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.tilerServer.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
         - name: {{ .Chart.Name }}-tiler-server
           image: "{{ .Values.tilerServer.image.name }}:{{ .Values.tilerServer.image.tag }}"

--- a/osm-seed/templates/tiler-server/tiler-server-statefulset.yaml
+++ b/osm-seed/templates/tiler-server/tiler-server-statefulset.yaml
@@ -24,6 +24,10 @@ spec:
         release: {{ .Release.Name }}
         run: {{ .Release.Name }}-tiler-server
     spec:
+      securityContext:
+        runAsUser: {{ .Values.tilerServer.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.tilerServer.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.tilerServer.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
         - name: {{ .Chart.Name }}-tiler-server
           image: "{{ .Values.tilerServer.image.name }}:{{ .Values.tilerServer.image.tag }}"

--- a/osm-seed/templates/tiler-visor/tiler-visor-deployment.yaml
+++ b/osm-seed/templates/tiler-visor/tiler-visor-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         release: {{ .Release.Name }}
         run: {{ .Release.Name }}-tiler-visor
     spec:
+      securityContext:
+        runAsUser: {{ .Values.tilerVisor.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.tilerVisor.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.tilerVisor.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
         - name: {{ .Chart.Name }}-tiler-visor
           image: "{{ .Values.tilerVisor.image.name }}:{{ .Values.tilerVisor.image.tag }}"

--- a/osm-seed/templates/web/web-deployment.yaml
+++ b/osm-seed/templates/web/web-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         release: {{ .Release.Name }}
         run: {{ .Release.Name }}-web
     spec:
+      securityContext:
+        runAsUser: {{ .Values.web.runAsUser | default .Values.runAsUser | default 0 }}
+        runAsGroup: {{ .Values.web.runAsGroup | default .Values.runAsGroup | default 0 }}
+        fsGroup: {{ .Values.web.fsGroup | default .Values.fsGroup | default 0 }}
       containers:
         - name: {{ .Chart.Name }}-web
           image: "{{ .Values.web.image.name }}:{{ .Values.web.image.tag }}"


### PR DESCRIPTION
As discussed here: https://github.com/developmentseed/osm-seed/issues/281

This PR is adding the security context for all containers. It is possible to define the runAsUser / runAsGroup / fsGroup for every container individually. If nothing is set on a container a global value is used. If no global value is configured the root user is used (as is now).

I think this should be rather undisputed. ;-) Tested except I cannot set the root user in my environment so not sure if explicitely setting default 0 works (but would surprise me if not).