### PR TITLE
Handle readonly containers

### DIFF
--- a/osm-seed/templates/db/db-statefulset.yaml
+++ b/osm-seed/templates/db/db-statefulset.yaml
@@ -69,6 +69,10 @@ spec:
             - name: postgres-storage
               mountPath: {{ .Values.db.persistenceDisk.mountPath }}
               subPath: {{ .Values.db.persistenceDisk.subPath }}
+            - name: tmp
+              mountPath: /tmp
+            - name: var-run
+              mountPath: /var/run
           {{- if .Values.db.resources.enabled }}
           resources:
             requests:
@@ -86,6 +90,10 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
+        - name: tmp
+          emptyDir: {}
+        - name: var-run
+          emptyDir: {}
       {{- if .Values.db.nodeSelector.enabled }}
       nodeSelector:
         {{ .Values.db.nodeSelector.label_key }} : {{ .Values.db.nodeSelector.label_value }}


### PR DESCRIPTION
As discussed here: https://github.com/developmentseed/osm-seed/issues/281

This is NOT intended to be merged yet - I would just like to initiate the discussion about the readonly containers with some sample.

In the discussion linked above I can see that you are somewhat sceptical about including the changes for the readonly containers as you worry it will complicate the chart significantly without being a requirement for most people.

I would like to convince you that this ain't the case by showing you what was required to get the db container to work. You can see that it merely required some directories to be specified as emptyDir (which will put a writeable memory drive in place of these folders that will be discarded when the container stops). From my point of view this is a very small change that will do no harm to anybody not running the containers readonly and benefit everyone who likes to do so. My impression is the real problem with this requirement is the time required to find the issues and fix them and not the resulting solution. But feel free to share your thoughts.

I am currently working on the web container which is slightly more complicated. However I think the final solution will be comparable to this one here once I figure out the cause for https://github.com/developmentseed/osm-seed/issues/283