### PR TITLE
Nominatim minute updates

### DIFF
--- a/compose/nominatim.yml
+++ b/compose/nominatim.yml
@@ -12,7 +12,7 @@ services:
       - '8080:8080'
       - '5432:5432'
     volumes:
-      - ../data/nominatim-data:/var/lib/postgresql/12/main
+      - ../data/nominatim-data:/var/lib/postgresql/14/main
       # - ../../Nominatim/nominatim/tokenizer/sanitizers:/usr/local/lib/nominatim/lib-python/nominatim/tokenizer/sanitizers
     env_file:
       - ../envs/.env.nominatim

--- a/images/nominatim/Dockerfile
+++ b/images/nominatim/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && \
         libboost-system-dev \
         libboost-filesystem-dev \
         git \
-        wget
+        wget \
+        cron
 # Nominatim install.
 RUN true \
     && git clone https://github.com/osm-search/Nominatim.git \
@@ -55,4 +56,5 @@ RUN true \
 ENV PGDATA=/var/lib/postgresql/14/main
 COPY docker-entrypoint.sh /app/
 COPY update.sh /app/
+RUN crontab -l | { cat; echo "* * * * * bash /app/update.sh >> /var/log/cron.log 2>&1"; } | crontab -
 CMD ["/app/docker-entrypoint.sh"]

--- a/images/nominatim/Dockerfile
+++ b/images/nominatim/Dockerfile
@@ -56,5 +56,5 @@ RUN true \
 ENV PGDATA=/var/lib/postgresql/14/main
 COPY docker-entrypoint.sh /app/
 COPY update.sh /app/
-RUN crontab -l | { cat; echo "* * * * * bash /app/update.sh >> /var/log/cron.log 2>&1"; } | crontab -
+RUN crontab -l | { cat; echo "* * * * * cd /nominatim/ ; bash /app/update.sh >> /var/log/cron.log 2>&1"; } | crontab -
 CMD ["/app/docker-entrypoint.sh"]

--- a/images/nominatim/Dockerfile
+++ b/images/nominatim/Dockerfile
@@ -54,4 +54,5 @@ RUN true \
 
 ENV PGDATA=/var/lib/postgresql/14/main
 COPY docker-entrypoint.sh /app/
+COPY update.sh /app/
 CMD ["/app/docker-entrypoint.sh"]

--- a/images/nominatim/README.md
+++ b/images/nominatim/README.md
@@ -9,3 +9,11 @@ In order to run this container we need environment variables, these can be found
 - [.env.nominatim.example](./../../envs/.env.nominatim.example)
 
 **Note**: Rename the above files as `.env.nominatim`
+
+
+### Log outputs
+
+```
+/var/log/replication.log
+/var/log/cron.log
+```

--- a/images/nominatim/README.md
+++ b/images/nominatim/README.md
@@ -10,8 +10,7 @@ In order to run this container we need environment variables, these can be found
 
 **Note**: Rename the above files as `.env.nominatim`
 
-
-### Log outputs
+### Log outputs in the container
 
 ```
 /var/log/replication.log

--- a/images/nominatim/docker-entrypoint.sh
+++ b/images/nominatim/docker-entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e
 CONFIG_FILE=${PROJECT_DIR}/.env
-# chmod 777 -R ${PROJECT_DIR}/
 if [[ ! -z "$NOMINATIM_ADDRESS_LEVEL_CONFIG_URL" ]]; then
     curl -o /app/address-levels.json "${NOMINATIM_ADDRESS_LEVEL_CONFIG_URL}"
     echo NOMINATIM_ADDRESS_LEVEL_CONFIG=/app/address-levels.json >> ${CONFIG_FILE}

--- a/images/nominatim/docker-entrypoint.sh
+++ b/images/nominatim/docker-entrypoint.sh
@@ -10,7 +10,4 @@ if [[ ! -z "$OSMSEED_WEB_API_DOMAIN" ]]; then
     find /usr/local/lib/nominatim/lib-python/nominatim/ -type f | xargs perl -pi -e "s/www.openstreetmap.org/${OSMSEED_WEB_API_DOMAIN}/g"
 fi
 
-/app/start.sh
-
-# Because of crashing updates, we are going to run updates every 10 minutes with catch-up action
-watch -n 600 sudo -u nominatim nominatim replication --project-dir ${PROJECT_DIR} --catch-up >> /var/log/replication.log
+/app/update.sh & /app/start.sh

--- a/images/nominatim/docker-entrypoint.sh
+++ b/images/nominatim/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 CONFIG_FILE=${PROJECT_DIR}/.env
-
+# chmod 777 -R ${PROJECT_DIR}/
 if [[ ! -z "$NOMINATIM_ADDRESS_LEVEL_CONFIG_URL" ]]; then
     curl -o /app/address-levels.json "${NOMINATIM_ADDRESS_LEVEL_CONFIG_URL}"
     echo NOMINATIM_ADDRESS_LEVEL_CONFIG=/app/address-levels.json >> ${CONFIG_FILE}
@@ -10,4 +10,5 @@ if [[ ! -z "$OSMSEED_WEB_API_DOMAIN" ]]; then
     find /usr/local/lib/nominatim/lib-python/nominatim/ -type f | xargs perl -pi -e "s/www.openstreetmap.org/${OSMSEED_WEB_API_DOMAIN}/g"
 fi
 
-/app/update.sh & /app/start.sh
+# Cron job is going activate updates even if the script fails once, next time it will start again
+cron & /app/start.sh

--- a/images/nominatim/update.sh
+++ b/images/nominatim/update.sh
@@ -7,5 +7,5 @@ while true; do
     if [ ! $? -ne 0 ]; then
         sudo -u nominatim nominatim replication --project-dir ${PROJECT_DIR} --catch-up >>/var/log/replication.log
     fi
-    sleep 10
+    sleep 60
 done

--- a/images/nominatim/update.sh
+++ b/images/nominatim/update.sh
@@ -1,11 +1,8 @@
 #!/bin/bash -e
 # Because of crashing updates, we wrote this small script to update every minute the Nominatim api
 LOCAL_API=http://localhost:8080
-while true; do
-    echo "Updating nominatim api.."
-    wget -q --spider $LOCAL_API
-    if [ ! $? -ne 0 ]; then
-        sudo -u nominatim nominatim replication --project-dir ${PROJECT_DIR} --catch-up >>/var/log/replication.log
-    fi
-    sleep 60
-done
+echo "Updating nominatim api...."
+wget -q --spider $LOCAL_API
+if [ ! $? -ne 0 ]; then
+    sudo -u nominatim nominatim replication --project-dir /nominatim --catch-up >>/var/log/replication.log
+fi

--- a/images/nominatim/update.sh
+++ b/images/nominatim/update.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+# Because of crashing updates, we wrote this small script to update every minute the Nominatim api
+LOCAL_API=http://localhost:8080
+while true; do
+    echo "Updating nominatim api.."
+    wget -q --spider $LOCAL_API
+    if [ ! $? -ne 0 ]; then
+        sudo -u nominatim nominatim replication --project-dir ${PROJECT_DIR} --catch-up >>/var/log/replication.log
+    fi
+    sleep 10
+done


### PR DESCRIPTION
- Adding script to update nominatim every minute,  since `watch -n 600` code  this has been not working well, the script evaluates the api and when the local api at port 8080 is ready it will start updating the api every minute.


cc. @batpad 