### PR TITLE
Cache  cleaner  - Delete tegola process after x numbers 

### DIFF
--- a/images/tiler-server/Dockerfile
+++ b/images/tiler-server/Dockerfile
@@ -52,4 +52,6 @@ COPY ./start.sh .
 COPY ./expire-watcher.sh .
 COPY ./seed-by-diffs.sh .
 COPY ./tile_cache_downloader.sh .
-CMD ./start.sh & ./tile_cache_downloader.sh & ./expire-watcher.sh
+COPY ./rm_tegola_ps.sh .
+
+CMD ./start.sh & ./tile_cache_downloader.sh & ./expire-watcher.sh & ./rm_tegola_ps.sh

--- a/images/tiler-server/cache_cleaner.sh
+++ b/images/tiler-server/cache_cleaner.sh
@@ -3,5 +3,5 @@ flag=true
 while "$flag" = true; do
   pg_isready -h $POSTGRES_HOST -p 5432 >/dev/null 2>&2 || continue
   flag=false
-  ./tile_cache_downloader.sh & ./expire-watcher.sh
+  ./tile_cache_downloader.sh & ./expire-watcher.sh & ./rm_tegola_ps.sh
 done

--- a/images/tiler-server/rm_tegola_ps.sh
+++ b/images/tiler-server/rm_tegola_ps.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -e
-if [[ -n "${CLEAN_CACHE_MANUALLY}" && "${CLEAN_CACHE_MANUALLY}" == "true" && "${TILER_CACHE_TYPE}" && "${TILER_CACHE_TYPE}" == "s3" ]]; then
+if [[ -n "${KILL_PROCESS}" && "${KILL_PROCESS}" == "manually" ]]; then
     while true; do
-        NUM_PS_TEGOLA=$(ps | grep ${CACHE_PROCESS_NAME} | grep -v grep | wc -l)
-        if [[ $NUM_PS_TEGOLA -gt $MAX_PS_TEGOLA ]]; then
+        NUM_PS=$(ps | grep ${PROCESS_NAME} | grep -v grep | wc -l)
+        if [[ $NUM_PS -gt $MAX_NUM_PS ]]; then
             aws s3 rm s3://${TILER_CACHE_BUCKET}/mnt/data/osm/ --recursive
-            echo "${CACHE_PROCESS_NAME} processes"
-            ps aux | grep ${CACHE_PROCESS_NAME} | grep -v grep
+            echo "${PROCESS_NAME} processes"
+            ps aux | grep ${PROCESS_NAME} | grep -v grep
             # After clearing the S3 cache, terminate all 'tegola' processes.
-            killall ${CACHE_PROCESS_NAME}
+            killall ${PROCESS_NAME}
         fi
         sleep 600
     done

--- a/images/tiler-server/rm_tegola_ps.sh
+++ b/images/tiler-server/rm_tegola_ps.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+if [[ -n "${CLEAN_CACHE_MANUALLY}" && "${CLEAN_CACHE_MANUALLY}" == "true" && "${TILER_CACHE_TYPE}" && "${TILER_CACHE_TYPE}" == "s3" ]]; then
+    while true; do
+        NUM_PS_TEGOLA=$(ps | grep ${CACHE_PROCESS_NAME} | grep -v grep | wc -l)
+        if [[ $NUM_PS_TEGOLA -gt $MAX_PS_TEGOLA ]]; then
+            aws s3 rm s3://${TILER_CACHE_BUCKET}/mnt/data/osm/ --recursive
+            echo "${CACHE_PROCESS_NAME} processes"
+            ps aux | grep ${CACHE_PROCESS_NAME} | grep -v grep
+            # After clearing the S3 cache, terminate all 'tegola' processes.
+            killall ${CACHE_PROCESS_NAME}
+        fi
+        sleep 600
+    done
+fi

--- a/osm-seed/templates/tiler-server/tiler-server-cache-cleaner-deployment.yaml
+++ b/osm-seed/templates/tiler-server/tiler-server-cache-cleaner-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - name: TILER_CACHE_MAX_ZOOM
               value: {{ quote .Values.tilerServer.env.TILER_CACHE_MAX_ZOOM }}
             - name: CLEAN_CACHE_MANUALLY
-              value: {{ .Values.tilerServerCacheCleaner.env.CLEAN_CACHE_MANUALLY }}
+              value: {{ quote .Values.tilerServerCacheCleaner.env.CLEAN_CACHE_MANUALLY }}
             - name: MAX_PS_TEGOLA
               value: {{ .Values.tilerServerCacheCleaner.env.MAX_PS_TEGOLA }}
             - name: CACHE_PROCESS_NAME

--- a/osm-seed/templates/tiler-server/tiler-server-cache-cleaner-deployment.yaml
+++ b/osm-seed/templates/tiler-server/tiler-server-cache-cleaner-deployment.yaml
@@ -62,12 +62,12 @@ spec:
               value: {{ quote .Values.tilerServer.env.TILER_CACHE_AWS_SECRET_ACCESS_KEY }}
             - name: TILER_CACHE_MAX_ZOOM
               value: {{ quote .Values.tilerServer.env.TILER_CACHE_MAX_ZOOM }}
-            - name: CLEAN_CACHE_MANUALLY
-              value: {{ quote .Values.tilerServerCacheCleaner.env.CLEAN_CACHE_MANUALLY }}
-            - name: MAX_PS_TEGOLA
-              value: {{ .Values.tilerServerCacheCleaner.env.MAX_PS_TEGOLA }}
-            - name: CACHE_PROCESS_NAME
-              value: {{ .Values.tilerServerCacheCleaner.env.CACHE_PROCESS_NAME }}
+            - name: MAX_NUM_PS
+              value: {{ .Values.tilerServerCacheCleaner.env.MAX_NUM_PS }}
+            - name: PROCESS_NAME
+              value: {{ .Values.tilerServerCacheCleaner.env.PROCESS_NAME }}
+            - name: KILL_PROCESS
+              value: {{ .Values.tilerServerCacheCleaner.env.KILL_PROCESS }}
             - name: CLOUDPROVIDER
               value: {{ .Values.cloudProvider }}
             # In case cloudProvider=aws

--- a/osm-seed/templates/tiler-server/tiler-server-cache-cleaner-deployment.yaml
+++ b/osm-seed/templates/tiler-server/tiler-server-cache-cleaner-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - name: TILER_CACHE_MAX_ZOOM
               value: {{ quote .Values.tilerServer.env.TILER_CACHE_MAX_ZOOM }}
             - name: MAX_NUM_PS
-              value: {{ .Values.tilerServerCacheCleaner.env.MAX_NUM_PS }}
+              value: {{ quote .Values.tilerServerCacheCleaner.env.MAX_NUM_PS }}
             - name: PROCESS_NAME
               value: {{ .Values.tilerServerCacheCleaner.env.PROCESS_NAME }}
             - name: KILL_PROCESS

--- a/osm-seed/templates/tiler-server/tiler-server-cache-cleaner-deployment.yaml
+++ b/osm-seed/templates/tiler-server/tiler-server-cache-cleaner-deployment.yaml
@@ -62,6 +62,12 @@ spec:
               value: {{ quote .Values.tilerServer.env.TILER_CACHE_AWS_SECRET_ACCESS_KEY }}
             - name: TILER_CACHE_MAX_ZOOM
               value: {{ quote .Values.tilerServer.env.TILER_CACHE_MAX_ZOOM }}
+            - name: CLEAN_CACHE_MANUALLY
+              value: {{ .Values.tilerServerCacheCleaner.env.CLEAN_CACHE_MANUALLY }}
+            - name: MAX_PS_TEGOLA
+              value: {{ .Values.tilerServerCacheCleaner.env.MAX_PS_TEGOLA }}
+            - name: CACHE_PROCESS_NAME
+              value: {{ .Values.tilerServerCacheCleaner.env.CACHE_PROCESS_NAME }}
             - name: CLOUDPROVIDER
               value: {{ .Values.cloudProvider }}
             # In case cloudProvider=aws

--- a/osm-seed/values.yaml
+++ b/osm-seed/values.yaml
@@ -451,6 +451,11 @@ tilerServerCacheCleaner:
     enabled: false
     label_key: nodegroup_type
     label_value: tiler
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 2
+    cpuUtilization: 60
 # ====================================================================================================
 # Variables for tiler-visor
 # ====================================================================================================

--- a/osm-seed/values.yaml
+++ b/osm-seed/values.yaml
@@ -444,9 +444,9 @@ tilerServerCacheCleaner:
       memory: '2Gi'
       cpu: '2'
   env:
-    CLEAN_CACHE_MANUALLY: true
-    MAX_PS_TEGOLA: 3
-    CACHE_PROCESS_NAME: tegola
+    KILL_PROCESS: manually
+    MAX_NUM_PS: 3
+    PROCESS_NAME: tegola
   nodeSelector:
     enabled: false
     label_key: nodegroup_type

--- a/osm-seed/values.yaml
+++ b/osm-seed/values.yaml
@@ -443,6 +443,10 @@ tilerServerCacheCleaner:
     limits:
       memory: '2Gi'
       cpu: '2'
+  env:
+    CLEAN_CACHE_MANUALLY: true
+    MAX_PS_TEGOLA: 3
+    CACHE_PROCESS_NAME: tegola
   nodeSelector:
     enabled: false
     label_key: nodegroup_type


### PR DESCRIPTION
The following script is designed to remove processes that overload the container. This is especially relevant when the tegola process doesn't finish and spawns numerous processes due to extensive editing on the api-server. We manually eliminate the tegola processes and also clear the S3 cache by hand.

cc. @batpad 