### PR TITLE
fix env var name for id key - OSM_id_key -> OPENSTREETMAP_id_key

### DIFF
--- a/envs/.env.web.example
+++ b/envs/.env.web.example
@@ -25,7 +25,7 @@ MAILER_PORT=25
 NOMINATIM_URL=nominatim-api
 
 # TODO: Describe those vars
-OSM_id_key="abcd..."
+OPENSTREETMAP_id_key="abcd..."
 OSM_memcache_servers=""
 
 # NEW_RELIC settings

--- a/envs/.env.web.example
+++ b/envs/.env.web.example
@@ -24,8 +24,9 @@ MAILER_PORT=25
 # Nominatim settings
 NOMINATIM_URL=nominatim-api
 
-# TODO: Describe those vars
-OPENSTREETMAP_id_key="abcd..."
+# Make sure that the first time this (OPENSTREETMAP_id_key) value is empty. 
+# Once you start you server and create your OAuth 1, fill the value with the Consumer Key.
+OPENSTREETMAP_id_key=""
 OSM_memcache_servers=""
 
 # NEW_RELIC settings


### PR DESCRIPTION
@Rub21 I think this env var needs to be OPENSTREETMAP_id_key, looking at https://github.com/developmentseed/osm-seed/blob/develop/images/web/start.sh#L31

I think we might have forgotten to update the example env after making these variable name changes recently?

Also, am not sure if we also need to change the OSM_memcache_servers variable name similarly at https://github.com/developmentseed/osm-seed/blob/develop/envs/.env.web.example#L29 ? I remember there being some changes we made to these names some point when upstream made some changes, but I forget the details a bit. Could you see if this makes sense and make any other changes to the env example I might have missed and we can merge this?

cc @majdal 