### PR TITLE
Simplify osm-processor image and reduce size

### DIFF
--- a/images/full-history/Dockerfile
+++ b/images/full-history/Dockerfile
@@ -1,4 +1,4 @@
-FROM developmentseed/osmseed-osm-processor:v2
+FROM developmentseed/osmseed-osm-processor:v3
 
 VOLUME /mnt/data
 COPY ./start.sh /

--- a/images/osm-processor/Dockerfile
+++ b/images/osm-processor/Dockerfile
@@ -1,73 +1,21 @@
-FROM ubuntu:20.04
+FROM debian:bookworm-slim
 ENV workdir /mnt/data
-
-RUN apt-get -y update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install  \
-    build-essential \
-    libboost-program-options-dev \
-    libbz2-dev \
-    zlib1g-dev \
-    libexpat1-dev \
-    cmake \
-    pandoc \
-    git \
-    python3 \
-    python3-pip \
-    curl \
-    unzip \
-    wget \
-    software-properties-common \
-    libz-dev \
-    gdal-bin \
-    tar \
-    bzip2 \
-    clang \
-    default-jre \
-    default-jdk \
-    gradle \
-    apt-utils \
-    postgresql-client
-
-# Install osmosis 0.48
-RUN echo "osmosis"
-RUN git clone https://github.com/openstreetmap/osmosis.git
-WORKDIR osmosis
-RUN git checkout bb0e592671a9bf0c48db1301cdc3d6085c88bae9
-RUN mkdir "$PWD"/dist
-RUN ./gradlew assemble
-RUN tar -xvzf "$PWD"/package/build/distribution/*.tgz -C "$PWD"/dist/
-RUN ln -s "$PWD"/dist/bin/osmosis /usr/bin/osmosis
-RUN osmosis --version 2>&1 | grep "Osmosis Version"
-
-# Install osmium-tool
-RUN apt-get -y install \
-    libbz2-dev \
-    libgd-dev \
-    libosmium2-dev \
-    libprotozero-dev \
-    libsqlite3-dev \
-    make \
-    jq \
-    ca-certificates
-
-# Other useful packages
-RUN apt-get install -y \
-    osmium-tool \
-    pyosmium \
-    rsync \
-    tmux \
-    zsh
-
-RUN pip install osmium
-
-# Install AWS CLI
-RUN pip install awscli
-
-# Install GCP CLI
-RUN curl -sSL https://sdk.cloud.google.com | bash
-RUN ln -f -s /root/google-cloud-sdk/bin/gsutil /usr/bin/gsutil
-
-# Install Azure CLI
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
-
 WORKDIR $workdir
+
+# Installs osmosis v0.48.3 & osmium-tool v1.15.0
+RUN set -ex \
+     && apt-get update \
+     && DEBIAN_FRONTEND=noninteractive apt-get install \
+     -y --no-install-recommends \
+        "osmosis" \
+        "osmium-tool" \
+        # Cloud provider CLIs
+        "awscli" \
+        "gsutil" \
+        "azure-cli" \
+        # Other useful packages
+        "rsync" \
+        "pyosmium" \
+        "tmux" \
+        "zsh" \
+     && rm -rf /var/lib/apt/lists/*

--- a/images/osm-processor/README.md
+++ b/images/osm-processor/README.md
@@ -10,7 +10,7 @@ Base container for other containers in osmseed ecosystem, it contains:
 
 ```
   cd osm-processor/
-  docker build -t osmseed-osm-processor:v1 .
+  docker build -t osmseed-osm-processor:v3 .
 ```
 
 #### Access the container
@@ -19,5 +19,5 @@ Base container for other containers in osmseed ecosystem, it contains:
   docker run --env-file ./../.env \
   --network osm-seed_default \
   -v $(pwd)/../osm-processor-data:/mnt/data \
-  -i -t osmseed-osm-processor:v1 bash
+  -i -t osmseed-osm-processor:v3 bash
 ```

--- a/images/planet-dump/Dockerfile
+++ b/images/planet-dump/Dockerfile
@@ -1,4 +1,4 @@
-FROM developmentseed/osmseed-osm-processor:v2
+FROM developmentseed/osmseed-osm-processor:v3
 
 VOLUME /mnt/data
 COPY ./start.sh /

--- a/images/populate-apidb/Dockerfile
+++ b/images/populate-apidb/Dockerfile
@@ -1,4 +1,4 @@
-FROM developmentseed/osmseed-osm-processor:v2
+FROM developmentseed/osmseed-osm-processor:v3
 
 VOLUME /mnt/data
 COPY ./start.sh /

--- a/images/replication-job/Dockerfile
+++ b/images/replication-job/Dockerfile
@@ -1,4 +1,4 @@
-FROM developmentseed/osmseed-osm-processor:v2
+FROM developmentseed/osmseed-osm-processor:v3
 
 # Install Nginx
 RUN apt-get update && \


### PR DESCRIPTION
## Issue

- The current osm-processor container on Dockerhub is very bloated at **4.56GB**.
  - The dockerfile does not utilise multistage builds.
  - `RUN` stages are also not combined anywhere, adding additional unnecessary layers to the image.
- Builds osmosis from source:
  - Currently this fails due to an issue that has since been fixed in osmosis `v0.49.0`.
  - Has little advantage, as we are building `v0.48.0`, but the latest deb package on Debian bookworm is `v0.48.3`

## Solution

- Swap to `debian:bookworm-slim` for small base image size.
- Simplifies dockerfile by installing all packages directly from Debian package repository.
- Combines install and cleanup into a single `RUN` stage to reduce number of image layers.

Resulting image size is **1.88GB** and contains all the same binaries / libs.