### PR TITLE
Add workflow to build osm-processor img in GHCR

### DIFF
--- a/.github/workflows/img_build.yaml
+++ b/.github/workflows/img_build.yaml
@@ -1,0 +1,60 @@
+name: Publish
+
+on: push
+
+env:
+    # Uses docker.io for Docker Hub if empty
+    REGISTRY: ghcr.io
+    # github.repository as <account>/<repo>
+    IMAGE_NAME: ${{ github.repository }}/processor
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            # Login against a Docker registry
+            # https://github.com/docker/login-action
+            - name: Log into registry ${{ env.REGISTRY }}
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            # Extract metadata (tags, labels) for Docker
+            # https://github.com/docker/metadata-action
+            - name: Extract Docker metadata
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+            # Setup QEMU emulator to build multi-arch images
+            # https://github.com/docker/setup-qemu-action
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+
+            # Configure Buildx for Docker build
+            # https://github.com/docker/setup-buildx-action
+            - name: Set up Buildx
+              uses: docker/setup-buildx-action@v3
+
+            # Build and push Docker image with Buildx
+            # https://github.com/docker/build-push-action
+            - name: Build and push Docker image
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  push: true
+                  # TODO the version tag should be dynamic in future
+                  tags: ${{ env.REGISTRY }}/{env.IMAGE_NAME}:v3
+                  # tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  platforms: 'linux/amd64,linux/arm64'

--- a/images/full-history/Dockerfile
+++ b/images/full-history/Dockerfile
@@ -1,4 +1,4 @@
-FROM developmentseed/osmseed-osm-processor:v2
+FROM ghcr.io/developmentseed/osm-seed/processor:v3
 
 VOLUME /mnt/data
 COPY ./start.sh /

--- a/images/osm-processor/README.md
+++ b/images/osm-processor/README.md
@@ -5,12 +5,12 @@ Base container for other containers in osmseed ecosystem, it contains:
 -  [osmosis](https://wiki.openstreetmap.org/wiki/Osmosis/Detailed_Usage_0.47)
 -  [osmium-tool](https://osmcode.org/osmium-tool/)
 
-#### Building the container
+#### Building the container manually
 
 
 ```
   cd osm-processor/
-  docker build -t osmseed-osm-processor:v1 .
+  docker build -t ghcr.io/developmentseed/osm-seed/processor:v3 .
 ```
 
 #### Access the container
@@ -19,5 +19,5 @@ Base container for other containers in osmseed ecosystem, it contains:
   docker run --env-file ./../.env \
   --network osm-seed_default \
   -v $(pwd)/../osm-processor-data:/mnt/data \
-  -i -t osmseed-osm-processor:v1 bash
+  -i -t ghcr.io/developmentseed/osm-seed/processor:v3 bash
 ```

--- a/images/planet-dump/Dockerfile
+++ b/images/planet-dump/Dockerfile
@@ -1,4 +1,4 @@
-FROM developmentseed/osmseed-osm-processor:v2
+FROM ghcr.io/developmentseed/osm-seed/processor:v3
 
 VOLUME /mnt/data
 COPY ./start.sh /

--- a/images/populate-apidb/Dockerfile
+++ b/images/populate-apidb/Dockerfile
@@ -1,4 +1,4 @@
-FROM developmentseed/osmseed-osm-processor:v2
+FROM ghcr.io/developmentseed/osm-seed/processor:v3
 
 VOLUME /mnt/data
 COPY ./start.sh /

--- a/images/replication-job/Dockerfile
+++ b/images/replication-job/Dockerfile
@@ -1,4 +1,4 @@
-FROM developmentseed/osmseed-osm-processor:v2
+FROM ghcr.io/developmentseed/osm-seed/processor:v3
 
 # Install Nginx
 RUN apt-get update && \


### PR DESCRIPTION
To be merged after https://github.com/developmentseed/osm-seed/pull/340

## Issue

- Currently the osm-processor img is built locally and I assume published on Dockerhub manually.

## Solution

- Add a Github workflow to build the image from this repo and publish.