### PR TITLE
Additional options and configuration for web container

### DIFF
--- a/compose/web.yml
+++ b/compose/web.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ####################################################
   # OSM API and Database section

--- a/envs/.env.web.example
+++ b/envs/.env.web.example
@@ -30,9 +30,10 @@ NOMINATIM_URL=nominatim-api
 # At initial startup the internal editor (iD) and the website must be registered as OAuth 2 applications.
 # See https://github.com/openstreetmap/openstreetmap-website/blob/master/CONFIGURE.md#oauth-setup
 # The bundled start script will try to register these applications.
+# If these values are automatically created, they are printed by the container at the very first startup.
 # These values are stored in the database and as configuration file in the container.
-# If the container is later re-created, these values must be addeded here in this configuration.
-# You could find these values in the account section of the admin account.
+# Automatically created values can be found in this file: $workdir/config/settings.local.yml
+# If the container is later re-created, these values must be before addeded here in this configuration.
 ## OAuth 2 settings for iD (editor)
 ### OAuth 2 Client ID for iD (editor)
 OPENSTREETMAP_id_key="xyz..."

--- a/envs/.env.web.example
+++ b/envs/.env.web.example
@@ -66,6 +66,9 @@ OPENSTREETMAP_trace_file_storage=s3
 OPENSTREETMAP_trace_image_storage=s3
 OPENSTREETMAP_trace_icon_storage=s3
 
+# Disable CGImap if you do not want to use it
+#EXTERNAL_CGIMAP=disabled
+
 # See https://guides.rubyonrails.org/security.html#environmental-security
 # Optional: if not set default values will be used
 RAILS_MASTER_KEY=""

--- a/envs/.env.web.example
+++ b/envs/.env.web.example
@@ -16,25 +16,31 @@ MAILER_PORT=25
 # # Mailer settings for gmail
 MAILER_ADDRESS=smtp.gmail.com
 MAILER_DOMAIN=gmail.com
+MAILER_AUTHENTICATION=login
 MAILER_USERNAME=test@gmail.com
 MAILER_PASSWORD=abc...
 MAILER_FROM=no-reply@osmseed.org
 MAILER_PORT=25
-OSM_memcache_servers=""
+OPENSTREETMAP_memcache_servers=""
 
 # Nominatim settings
 NOMINATIM_URL=nominatim-api
 
-# Make sure that the first time this (OPENSTREETMAP_id_key) value is empty. 
-# Once you start you server and create your OAuth 2.
-### Create OAuth 2 applications
-### Client ID=OPENSTREETMAP_id_key
+# OAuth 2 settings
+# At initial startup the internal editor (iD) and the website must be registered as OAuth 2 applications.
+# See https://github.com/openstreetmap/openstreetmap-website/blob/master/CONFIGURE.md#oauth-setup
+# The bundled start script will try to register these applications.
+# These values are stored in the database and as configuration file in the container.
+# If the container is later re-created, these values must be addeded here in this configuration.
+# You could find these values in the account section of the admin account.
+## OAuth 2 settings for iD (editor)
+### OAuth 2 Client ID for iD (editor)
 OPENSTREETMAP_id_key="xyz..."
 
-### OpenStreetMap Web Site
-# Client ID=OAUTH_CLIENT_ID
-# Client Secret=OAUTH_KEY	
+## OAuth 2 settings for the OpenStreetMap web site
+### OAuth 2 Client ID for the web site
 OAUTH_CLIENT_ID="abc..."
+### OAuth 2 Client Secret for the web site
 OAUTH_KEY="efg..."
 
 # NEW_RELIC settings
@@ -44,3 +50,29 @@ NEW_RELIC_APP_NAME="..."
 
 ### Set organization name, by default : OpenStreetMap
 ORGANIZATION_NAME=OSMSeed
+
+# Application status - possible values are:
+#   online - online and operating normally
+#   api_readonly - site online but API in read-only mode
+#   api_offline - site online but API offline
+#   database_readonly - database and site in read-only mode
+#   database_offline - database offline with site in emergency mode
+#   gpx_offline - gpx storage offline
+WEBSITE_STATUS=online
+
+# Storage: local or s3 are good choices
+OPENSTREETMAP_avatar_storage=s3
+OPENSTREETMAP_trace_file_storage=s3
+OPENSTREETMAP_trace_image_storage=s3
+OPENSTREETMAP_trace_icon_storage=s3
+
+# See https://guides.rubyonrails.org/security.html#environmental-security
+# Optional: if not set default values will be used
+RAILS_MASTER_KEY=""
+RAILS_CREDENTIALS_YML_ENC=""
+
+# Create user 'admin' with following attributes at first start
+# If set, also default OAuth 2 applications will be registered
+ADMIN_MAIL="admin@osmseed.org"
+# Password must be at least 8 characters or user creation will fail!
+ADMIN_PASSWORD=""

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -68,6 +68,10 @@ RUN SECRET_KEY_BASE_DUMMY=1  \
     bundle exec i18n export && \
     bundle exec rails assets:precompile
 
+# Apply patches for OSM
+COPY patches/ /$workdir/
+RUN patch /$workdir/config/initializers/doorkeeper.rb /$workdir/config/initializers/doorkeeper.rb.patch
+
 
 FROM ruby:3.3-slim
 

--- a/images/web/config/production.conf
+++ b/images/web/config/production.conf
@@ -26,8 +26,12 @@
 
     #Proxying traffic to CGImap
     ProxyTimeout 1200
+    RewriteCond %{ENV:EXTERNAL_CGIMAP} !=disabled
     RewriteCond %{REQUEST_URI} ^/api/0\.6/map
     RewriteRule ^/api/0\.6/map(\.json|\.xml)?$ fcgi://${CGIMAP_URL}:${CGIMAP_PORT}$0 [P]
+
+    RewriteCond %{ENV:EXTERNAL_CGIMAP} =disabled
+    RewriteRule .? - [S=7]
     RewriteRule ^/api/0\.6/(node|way|relation|changeset)/[0-9]+(\.json|\.xml)?$ fcgi://${CGIMAP_URL}:${CGIMAP_PORT}$0 [P]
     RewriteRule ^/api/0\.6/(node|way|relation)/[0-9]+/history(\.json|\.xml)?$ fcgi://${CGIMAP_URL}:${CGIMAP_PORT}$0 [P]
     RewriteRule ^/api/0\.6/(node|way|relation)/[0-9]+/relations(\.json|\.xml)?$ fcgi://${CGIMAP_URL}:${CGIMAP_PORT}$0 [P]

--- a/images/web/config/production.conf
+++ b/images/web/config/production.conf
@@ -14,6 +14,8 @@
     RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
     RewriteCond %{HTTP_HOST} =SERVER_DOMAIN_PLACEHOLDER
+    RewriteCond %{HTTP_HOST} !=localhost
+    RewriteCond %{HTTP_HOST} !=127.0.0.1
     RewriteCond %{HTTP_HOST} !^www\. [NC]
     RewriteRule .* https://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 

--- a/images/web/patches/config/initializers/doorkeeper.rb.patch
+++ b/images/web/patches/config/initializers/doorkeeper.rb.patch
@@ -1,0 +1,4 @@
+270c270
+<     !Rails.env.development? && uri.host != "127.0.0.1"
+---
+>     !Rails.env.development? && !["127.0.0.1", "localhost"].include?(uri.host)

--- a/images/web/start.sh
+++ b/images/web/start.sh
@@ -42,6 +42,10 @@ EOF
   SERVER_URL_CLEAN=$(echo "$SERVER_URL" | sed 's|/$||')
   sed -i -e 's/^server_protocol: ".*"/server_protocol: "'$SERVER_PROTOCOL'"/g' $workdir/config/settings.yml
   sed -i -e 's/^server_url: ".*"/server_url: "'$SERVER_URL_CLEAN'"/g' $workdir/config/settings.yml
+  if [ "$SERVER_PROTOCOL" == "http" ]; then
+    sed -i -e 's/config.force_ssl = true/config.force_ssl = false/' $workdir/config/environments/production.rb
+    sed -i -e 's/config.assume_ssl = true/config.assume_ssl = false/' $workdir/config/environments/production.rb
+  fi
 
   #### Extract domain from SERVER_URL and replace in production.conf
   SERVER_DOMAIN=$(echo "$SERVER_URL_CLEAN" | sed -e 's|^[^/]*//||' -e 's|^www\.||' -e 's|/.*$||')
@@ -54,9 +58,16 @@ EOF
   sed -i -e 's/smtp_address: ".*"/smtp_address: "'$MAILER_ADDRESS'"/g' $workdir/config/settings.yml
   sed -i -e 's/smtp_port: .*/smtp_port: '$MAILER_PORT'/g' $workdir/config/settings.yml
   sed -i -e 's/smtp_domain: ".*"/smtp_domain: "'$MAILER_DOMAIN'"/g' $workdir/config/settings.yml
-  sed -i -e 's/smtp_authentication: .*/smtp_authentication: "login"/g' $workdir/config/settings.yml
-  sed -i -e 's/smtp_user_name: .*/smtp_user_name: "'$MAILER_USERNAME'"/g' $workdir/config/settings.yml
-  sed -i -e 's/smtp_password: .*/smtp_password: "'$MAILER_PASSWORD'"/g' $workdir/config/settings.yml
+
+  if [ "$MAILER_AUTHENTICATION" == "" ]; then
+    sed -i -e 's/smtp_authentication: .*/smtp_authentication: null/g' $workdir/config/settings.yml
+    sed -i -e 's/smtp_user_name: .*/smtp_user_name: null/g' $workdir/config/settings.yml
+    sed -i -e 's/smtp_password: .*/smtp_password: null/g' $workdir/config/settings.yml
+  else
+    sed -i -e 's/smtp_authentication: .*/smtp_authentication: "'$MAILER_AUTHENTICATION'"/g' $workdir/config/settings.yml
+    sed -i -e 's/smtp_user_name: .*/smtp_user_name: "'$MAILER_USERNAME'"/g' $workdir/config/settings.yml
+    sed -i -e 's/smtp_password: .*/smtp_password: "'$MAILER_PASSWORD'"/g' $workdir/config/settings.yml
+  fi
 
   ### Setting up oauth id and key for iD editor
   sed -i -e 's/^oauth_application: ".*"/oauth_application: "'$OAUTH_CLIENT_ID'"/g' $workdir/config/settings.yml
@@ -68,6 +79,12 @@ EOF
   #### Setup env vars for memcached server
   sed -i -e 's/memcache_servers: \[\]/memcache_servers: "'$OPENSTREETMAP_memcache_servers'"/g' $workdir/config/settings.yml
 
+  ## Setting up storage
+  sed -i -e 's/avatar_storage: ".*"/avatar_storage: "'$OPENSTREETMAP_avatar_storage'"/g' $workdir/config/settings.yml
+  sed -i -e 's/trace_file_storage: ".*"/trace_file_storage: "'$OPENSTREETMAP_trace_file_storage'"/g' $workdir/config/settings.yml
+  sed -i -e 's/trace_image_storage: ".*"/trace_image_storage: "'$OPENSTREETMAP_trace_image_storage'"/g' $workdir/config/settings.yml
+  sed -i -e 's/trace_icon_storage: ".*"/trace_icon_storage: "'$OPENSTREETMAP_trace_icon_storage'"/g' $workdir/config/settings.yml
+
   #### Setting up nominatim url
   sed -i -e 's/nominatim-api.openstreetmap.org/'$NOMINATIM_URL'/g' $workdir/config/settings.yml
 
@@ -77,8 +94,10 @@ EOF
   sed -i -e 's/overpass-api.de/'$OVERPASS_URL'/g' $workdir/app/assets/javascripts/index/export.js
 
   ## Setting up required credentials 
-  echo $RAILS_CREDENTIALS_YML_ENC > config/credentials.yml.enc
-  echo $RAILS_MASTER_KEY > config/master.key 
+  if [ "$RAILS_MASTER_KEY" != "" ]; then
+    echo $RAILS_CREDENTIALS_YML_ENC > config/credentials.yml.enc
+    echo $RAILS_MASTER_KEY > config/master.key
+  fi
   chmod 600 config/credentials.yml.enc config/master.key
 
   #### Adding doorkeeper_signing_key
@@ -86,7 +105,45 @@ EOF
   chmod 400 /var/www/private.pem
   export DOORKEEPER_SIGNING_KEY=$(cat /var/www/private.pem | sed -e '1d;$d' | tr -d '\n')
   sed -i "s#PRIVATE_KEY#${DOORKEEPER_SIGNING_KEY}#" $workdir/config/settings.yml
+}
 
+setup_admin() {
+  ### Create default admin and register default oauth apps
+  if [ $ADMIN_MAIL != "" ] && [ ! -f $workdir/.admin_created ]; then
+    echo "Creating user 'admin' ..."
+    touch $workdir/.admin_created
+
+    bundle exec rails runner "u = User.find_by(:display_name => 'admin'); \
+        if (nil != u) then puts('User already exists'); exit(2) end;
+        u = User.new(email:'$ADMIN_MAIL', display_name: 'admin'); \
+        u.pass_crypt='$ADMIN_PASSWORD'; \
+        u.pass_crypt_confirmation='$ADMIN_PASSWORD'; \
+        u.save"'!'"; \
+        u.activate"'!'"; \
+        u.roles.create(:role => \"moderator\", :granter_id => u.id); \
+        u.roles.create(:role => \"administrator\", :granter_id => u.id); \
+        exit(0);"
+
+    if [ $? -eq 0 ]; then # Success: 0
+      echo "Creating user 'admin': Success!"
+    else # Error: 1
+      echo "Creating user 'admin': Failure!"
+    fi
+
+    bundle exec rails runner 'exit(nil == Oauth2Application.find_by(:name => "Local iD"))' # true converted to result code 0
+    if [ $? -eq 0 ]; then
+      echo "Registering default OAuth2 applications for user 'admin' ..."
+
+      sed -i -e 's/^id_application:/#id_application:/' $workdir/config/settings.yml
+      sed -i -e 's/^oauth_application:/#oauth_application:/' $workdir/config/settings.yml
+      sed -i -e 's/^oauth_key:/#oauth_key:/' $workdir/config/settings.yml
+
+      bundle exec rails oauth:register_apps["admin"]
+    else
+      echo "OAuth2 default applications already exist. No new applications registered."
+    fi
+
+  fi
 }
 
 restore_db() {
@@ -135,6 +192,8 @@ setup_production() {
   echo "Running database migrations..."
   time bundle exec rails db:migrate
 
+  setup_admin
+
   if [ "$EXTERNAL_CGIMAP" == "false" ]; then
     echo "Running cgimap..."
     ./cgimap.sh
@@ -158,6 +217,7 @@ setup_development() {
   setup_env_vars
   bundle exec bin/yarn install
   bundle exec rails db:migrate --trace
+  setup_admin
   bundle exec rake jobs:work &
   rails server --log-to-stdout
 }

--- a/images/web/start.sh
+++ b/images/web/start.sh
@@ -139,6 +139,8 @@ setup_admin() {
       sed -i -e 's/^oauth_key:/#oauth_key:/' $workdir/config/settings.yml
 
       bundle exec rails oauth:register_apps["admin"]
+
+      cat $workdir/config/settings.local.yml
     else
       echo "OAuth2 default applications already exist. No new applications registered."
     fi


### PR DESCRIPTION
- option to automatically create admin acount at first startup
- register default OAuth2 applications at first startup if no other applications are registered yet
- allow "localhost" as valid server name
- additional comments in .env.web.example
- allow changing storage in env file
- allow email to smtp relay without password
- option to not use CGImap but use only the osm-website